### PR TITLE
Fix chat route link in frontend nav

### DIFF
--- a/frontend/src/components/headerNav.vue
+++ b/frontend/src/components/headerNav.vue
@@ -2,7 +2,7 @@
   <nav class="flex flex-row justify-between items-center py-2 text-lg md:text-sm max-w-[1200px]">
     <div class="flex flex-row">
       <RouterLink v-for="l in links" class="flex items-center gap-x-1.5 px-3 xs:px-2 md:px-2 hovering"
-        :class="{ 'curved': l.name == 'home' }" :to="{ path: '/', hash: l.hash }">
+        :class="{ 'curved': l.name == 'home' }" :to="l.hash.startsWith('#') ? { path: '/', hash: l.hash } : l.hash">
         <SvgIcon type="mdi" :path="l.icon" />
         <div class="block xs:hidden" :class="{ 'sm:hidden xs:hidden': l.name != 'home' }">{{ $t(l.name) }}</div>
       </RouterLink>


### PR DESCRIPTION
## Summary
- fix link object for navigating to chat page without Vue Router warnings

## Testing
- `yarn install` *(fails: vite peer dependencies)*
- `yarn build` *(fails: could not resolve signin.vue)*

------
https://chatgpt.com/codex/tasks/task_e_6870bf037aac8329bc089d59e3096009