### PR TITLE
Implement signup form

### DIFF
--- a/frontend/src/utils/translation.js
+++ b/frontend/src/utils/translation.js
@@ -45,6 +45,10 @@ const arWords = {
   instegram: 'انستغرام',
   twitter: 'تويتر',
   contact: 'تواصل معنا عبر:',
+  signUp: 'انشاء حساب',
+  email: 'البريد الالكتروني',
+  password: 'كلمة المرور',
+  confirmPassword: 'تأكيد كلمة المرور',
 }
 
 const enWords = {
@@ -94,6 +98,10 @@ const enWords = {
   instegram: 'Instegram',
   twitter: 'Twitter',
   contact: 'contact us via:',
+  signUp: 'Sign Up',
+  email: 'Email',
+  password: 'Password',
+  confirmPassword: 'Confirm Password',
 }
 
 export const words = {

--- a/frontend/src/views/signup.vue
+++ b/frontend/src/views/signup.vue
@@ -1,5 +1,45 @@
 <template>
-  <div class="flex flex-col px-5 relative overflow-hidden">
-    
+  <div class="flex flex-col items-center justify-center gap-4 py-10">
+    <input
+      v-model="email"
+      type="email"
+      :placeholder="$t('email')"
+      class="border border-gray-300 rounded px-3 py-2 w-80 max-w-full"
+    />
+    <input
+      v-model="password"
+      type="password"
+      :placeholder="$t('password')"
+      class="border border-gray-300 rounded px-3 py-2 w-80 max-w-full"
+    />
+    <input
+      v-model="confirmPassword"
+      type="password"
+      :placeholder="$t('confirmPassword')"
+      class="border border-gray-300 rounded px-3 py-2 w-80 max-w-full"
+    />
+    <button
+      @click="onSignUp"
+      class="bg-blue-500 text-white rounded px-3 py-2 w-80 max-w-full"
+    >
+      {{ $t('signUp') }}
+    </button>
   </div>
 </template>
+
+<script setup>
+import { ref } from 'vue'
+
+const email = ref('')
+const password = ref('')
+const confirmPassword = ref('')
+
+const onSignUp = () => {
+  if (password.value !== confirmPassword.value) {
+    alert('Passwords do not match')
+    return
+  }
+  // TODO: connect with backend API
+  console.log('Sign up', email.value)
+}
+</script>


### PR DESCRIPTION
## Summary
- add signup email & password fields with basic validation
- localize signup terms in the translation file

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870bf7c281483298b7abb2c14837926