### PR TITLE
Add frontend validation for signup

### DIFF
--- a/frontend/src/views/signup.vue
+++ b/frontend/src/views/signup.vue
@@ -34,6 +34,15 @@ const confirmPassword = ref('')
 const showPassword = ref(false)
 
 const onSignUp = () => {
+  const emailRegex = /\S+@\S+\.\S+/
+  if (!emailRegex.test(email.value)) {
+    alert('Please enter a valid email')
+    return
+  }
+  if (password.value.length < 8) {
+    alert('Password must be at least 8 characters')
+    return
+  }
   if (password.value !== confirmPassword.value) {
     alert('Passwords do not match')
     return


### PR DESCRIPTION
## Summary
- ensure the signup form checks for a valid email address
- ensure password is at least eight characters

## Testing
- `yarn install`
- `yarn build` *(fails: Could not resolve '../views/signin.vue')*

------
https://chatgpt.com/codex/tasks/task_e_6870d4a548e08329a85b837dd6b285ec